### PR TITLE
feat: add wait api for initiator.

### DIFF
--- a/initiator.go
+++ b/initiator.go
@@ -4,8 +4,12 @@ import (
 	"bufio"
 	"crypto/tls"
 	"errors"
+	"math"
+	"os"
+	"os/signal"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"golang.org/x/net/proxy"
@@ -23,11 +27,25 @@ type Initiator struct {
 	wg              sync.WaitGroup
 	sessions        map[SessionID]*session
 	sessionFactory
+
+	// append member
+	stateChangeChan chan SessionID
+	registerChan    chan notifyRequestData
+	unregisterChan  chan uint64
+	notifyCounter   uint64
+	counterMap      map[uint64]bool
+	counterMutex    sync.Mutex
 }
 
 //Start Initiator.
 func (i *Initiator) Start() (err error) {
 	i.stopChan = make(chan interface{})
+	i.stateChangeChan = make(chan SessionID)
+	i.registerChan = make(chan notifyRequestData)
+	i.unregisterChan = make(chan uint64)
+
+	i.wg.Add(1)
+	go i.checkStateLoop()
 
 	for sessionID, settings := range i.sessionSettings {
 		//TODO: move into session factory
@@ -43,6 +61,7 @@ func (i *Initiator) Start() (err error) {
 
 		i.wg.Add(1)
 		go func(sessID SessionID) {
+			i.sessions[sessID].stateChangeChan = i.stateChangeChan
 			i.handleConnection(i.sessions[sessID], tlsConfig, dialer)
 			i.wg.Done()
 		}(sessionID)
@@ -53,6 +72,11 @@ func (i *Initiator) Start() (err error) {
 
 //Stop Initiator.
 func (i *Initiator) Stop() {
+	defer func() {
+		close(i.stateChangeChan)
+		close(i.registerChan)
+		close(i.unregisterChan)
+	}()
 	select {
 	case <-i.stopChan:
 		//closed already
@@ -73,6 +97,7 @@ func NewInitiator(app Application, storeFactory MessageStoreFactory, appSettings
 		logFactory:      logFactory,
 		sessions:        make(map[SessionID]*session),
 		sessionFactory:  sessionFactory{true},
+		counterMap:      make(map[uint64]bool),
 	}
 
 	var err error
@@ -204,6 +229,76 @@ func (i *Initiator) handleConnection(session *session, tlsConfig *tls.Config, di
 
 // append API ------------------------------------------------------------------
 
+var ErrWaitCancel = errors.New("wait cancel")
+var ErrWaitTimeout = errors.New("wait timeout")
+var ErrInternalError = errors.New("internal error")
+
+type notifyCheckResponse struct {
+	canSendResponse bool
+	err             error
+}
+
+type notifyRequestData struct {
+	id        uint64
+	checkFunc func(SessionID) notifyCheckResponse
+	response  chan error
+}
+
+func (i *Initiator) checkStateLoop() {
+	defer i.wg.Done()
+	notifyMap := make(map[uint64]notifyRequestData)
+
+	for {
+		select {
+		case <-i.stopChan:
+			return
+		case data, ok := <-i.registerChan:
+			if ok {
+				notifyMap[data.id] = data
+			}
+		case id, ok := <-i.unregisterChan:
+			if ok {
+				delete(notifyMap, id)
+			}
+		case sessionID, ok := <-i.stateChangeChan:
+			if !ok {
+				// do nothing
+			} else if sess, exist := i.sessions[sessionID]; exist && sess.IsLoggedOn() {
+				for _, data := range notifyMap {
+					if resp := data.checkFunc(sessionID); resp.canSendResponse {
+						data.response <- resp.err
+					}
+				}
+			}
+		}
+	}
+}
+
+func (i *Initiator) keepNotifyCounter() uint64 {
+	i.counterMutex.Lock()
+	defer i.counterMutex.Unlock()
+	count := i.notifyCounter
+	for {
+		if count < math.MaxUint64 {
+			count++
+		} else {
+			count = 1
+		}
+		_, ok := i.counterMap[count]
+		if !ok {
+			i.counterMap[count] = true
+			i.notifyCounter = count
+			return count
+		}
+	}
+}
+
+func (i *Initiator) releaseNotifyCounter(count uint64) {
+	i.counterMutex.Lock()
+	defer i.counterMutex.Unlock()
+	delete(i.counterMap, count)
+}
+
 // GetAliveSessionIDs This function returns loggedOn sessionID list.
 func (i *Initiator) GetAliveSessionIDs() []SessionID {
 	sessionIds := make([]SessionID, 0, len(i.sessions))
@@ -243,4 +338,105 @@ func (i *Initiator) SendToAliveSessions(m Messagable) (err error) {
 		errObj.error = errors.New("failed to SendToAliveSessions")
 	}
 	return err
+}
+
+// WaitForAliveSessionFirst This function wait for the session to become alive first.
+func (i *Initiator) WaitForAliveSessionFirst() error {
+	return i.WaitForAliveSessionFirstTimeout(time.Hour * 24 * 365 * 10)
+}
+
+// WaitForAliveSessionFirstTimeout This function wait for the session to become alive first.
+func (i *Initiator) WaitForAliveSessionFirstTimeout(timeout time.Duration) error {
+	sessions := i.GetAliveSessionIDs()
+	if len(sessions) > 0 {
+		return nil
+	}
+	data := notifyRequestData{
+		id: i.keepNotifyCounter(),
+		checkFunc: func(_sessionId SessionID) notifyCheckResponse {
+			sessions := i.GetAliveSessionIDs()
+			resp := notifyCheckResponse{}
+			if len(sessions) > 0 {
+				resp.canSendResponse = true
+			}
+			return resp
+		},
+	}
+	defer i.releaseNotifyCounter(data.id)
+	return i.waitForAliveSessionTimeout(data, timeout)
+}
+
+// WaitForAliveSessionAll This function wait for all sessions to become alive.
+func (i *Initiator) WaitForAliveSessionAll() error {
+	return i.WaitForAliveSessionAllTimeout(time.Hour * 24 * 365 * 10)
+}
+
+// WaitForAliveSessionAllTimeout This function wait for all sessions to become alive.
+func (i *Initiator) WaitForAliveSessionAllTimeout(timeout time.Duration) error {
+	sessions := i.GetAliveSessionIDs()
+	if len(sessions) == len(i.sessions) {
+		return nil
+	}
+	data := notifyRequestData{
+		id: i.keepNotifyCounter(),
+		checkFunc: func(_sessionId SessionID) notifyCheckResponse {
+			sessions := i.GetAliveSessionIDs()
+			resp := notifyCheckResponse{}
+			if len(sessions) == len(i.sessions) {
+				resp.canSendResponse = true
+			}
+			return resp
+		},
+	}
+	defer i.releaseNotifyCounter(data.id)
+	return i.waitForAliveSessionTimeout(data, timeout)
+}
+
+// waitForAliveSessionTimeout This function wait for sessions to become alive.
+func (i *Initiator) waitForAliveSessionTimeout(req notifyRequestData, timeout time.Duration) error {
+	select {
+	case <-i.stopChan:
+		return ErrWaitCancel //closed already
+	default:
+	}
+	data := req
+	data.response = make(chan error)
+	defer close(data.response)
+
+	i.registerChan <- data
+	defer func() {
+		select {
+		case <-i.stopChan:
+			// closed already
+			break
+		default:
+			i.unregisterChan <- data.id
+		}
+	}()
+
+	interrupt := make(chan os.Signal, 1)
+	signal.Notify(interrupt, os.Interrupt, syscall.SIGTERM) // os.Kill
+	defer close(interrupt)
+	waitTimer := time.NewTimer(timeout)
+	defer waitTimer.Stop()
+	var err error
+
+	select {
+	case <-i.stopChan:
+		err = ErrWaitCancel
+		return err
+	case <-interrupt:
+		err = ErrWaitCancel
+		return err
+	case resp, ok := <-data.response:
+		if ok {
+			err = resp
+		} else {
+			err = ErrInternalError
+		}
+		return err
+	case <-waitTimer.C:
+		err = ErrWaitTimeout
+		return err
+	}
 }

--- a/logon_state.go
+++ b/logon_state.go
@@ -41,6 +41,12 @@ func (s logonState) FixMsgIn(session *session, msg *Message) (nextState sessionS
 			return handleStateError(session, err)
 		}
 	}
+
+	if session.notifyOnce != nil {
+		session.notifyOnce.Do(func() {
+			close(session.notifyLogon)
+		})
+	}
 	return inSession{}
 }
 

--- a/logon_state.go
+++ b/logon_state.go
@@ -41,12 +41,6 @@ func (s logonState) FixMsgIn(session *session, msg *Message) (nextState sessionS
 			return handleStateError(session, err)
 		}
 	}
-
-	if session.notifyOnce != nil {
-		session.notifyOnce.Do(func() {
-			close(session.notifyLogon)
-		})
-	}
 	return inSession{}
 }
 

--- a/logon_state_test.go
+++ b/logon_state_test.go
@@ -20,6 +20,7 @@ func TestLogonStateTestSuite(t *testing.T) {
 func (s *LogonStateTestSuite) SetupTest() {
 	s.Init()
 	s.session.stateMachine.State = logonState{}
+	s.session.notifyLogonEvent = make(chan struct{}, 1)
 }
 
 func (s *LogonStateTestSuite) TestPreliminary() {

--- a/registry.go
+++ b/registry.go
@@ -204,7 +204,7 @@ func fillHeaderBySessionID(m *Message, sessionID SessionID) *Message {
 	return m
 }
 
-// WaitLogon This function wait for logon session.
+// WaitForLogon returns channel to receive logon event by specific session. if non-existing sessionID specified, it returns nil which blocks forever.
 func WaitForLogon(sessionID SessionID) <-chan struct{} {
 	sessionsLock.Lock()
 	defer sessionsLock.Unlock()

--- a/registry.go
+++ b/registry.go
@@ -104,6 +104,17 @@ func NewErrorBySessionID(err error) (response *ErrorBySessionID) {
 	return response
 }
 
+// GetSessionIDs This function returns sessionID list.
+func GetSessionIDs() []SessionID {
+	sessionsLock.Lock()
+	defer sessionsLock.Unlock()
+	sessionIds := make([]SessionID, 0, len(sessions))
+	for sessionID := range sessions {
+		sessionIds = append(sessionIds, sessionID)
+	}
+	return sessionIds
+}
+
 // GetAliveSessionIDs This function returns loggedOn sessionID list.
 func GetAliveSessionIDs() []SessionID {
 	sessionsLock.Lock()
@@ -191,4 +202,14 @@ func fillHeaderBySessionID(m *Message, sessionID SessionID) *Message {
 		m.Header.SetField(tagTargetLocationID, FIXString(sessionID.TargetLocationID))
 	}
 	return m
+}
+
+// WaitLogon This function wait for logon session.
+func WaitLogon(sessionID SessionID) <-chan struct{} {
+	sessionsLock.Lock()
+	defer sessionsLock.Unlock()
+	if session, ok := sessions[sessionID]; ok {
+		return session.notifyLogon
+	}
+	return nil
 }

--- a/registry.go
+++ b/registry.go
@@ -209,7 +209,7 @@ func WaitForLogon(sessionID SessionID) <-chan struct{} {
 	sessionsLock.Lock()
 	defer sessionsLock.Unlock()
 	if session, ok := sessions[sessionID]; ok {
-		return session.notifyLogon
+		return session.notifyLogonEvent
 	}
-	return nil
+	return nil // fail case
 }

--- a/registry.go
+++ b/registry.go
@@ -205,7 +205,7 @@ func fillHeaderBySessionID(m *Message, sessionID SessionID) *Message {
 }
 
 // WaitLogon This function wait for logon session.
-func WaitLogon(sessionID SessionID) <-chan struct{} {
+func WaitForLogon(sessionID SessionID) <-chan struct{} {
 	sessionsLock.Lock()
 	defer sessionsLock.Unlock()
 	if session, ok := sessions[sessionID]; ok {

--- a/session.go
+++ b/session.go
@@ -74,10 +74,6 @@ func (s *session) connect(msgIn <-chan fixIn, msgOut chan<- []byte) error {
 		err:        rep,
 	}
 
-	if s.notifyLogon == nil {
-		s.notifyLogon = make(chan struct{})
-		s.notifyOnce = &sync.Once{}
-	}
 	return <-rep
 }
 
@@ -733,6 +729,11 @@ func (s *session) onAdmin(msg interface{}) {
 				close(msg.err)
 			}
 			return
+		}
+
+		if s.notifyLogon == nil {
+			s.notifyLogon = make(chan struct{})
+			s.notifyOnce = &sync.Once{}
 		}
 
 		if msg.err != nil {

--- a/session_factory.go
+++ b/session_factory.go
@@ -299,6 +299,7 @@ func (f sessionFactory) newSession(
 	s.sessionEvent = make(chan internal.Event)
 	s.messageEvent = make(chan bool, 1)
 	s.admin = make(chan interface{})
+	s.notifyLogonEvent = make(chan struct{}, 1)
 	s.application = application
 	return
 }

--- a/session_state.go
+++ b/session_state.go
@@ -177,14 +177,23 @@ func (sm *stateMachine) handleDisconnectState(s *session) {
 }
 
 func (sm *stateMachine) IsLoggedOn() bool {
+	if sm.State == nil {
+		return false
+	}
 	return sm.State.IsLoggedOn()
 }
 
 func (sm *stateMachine) IsConnected() bool {
+	if sm.State == nil {
+		return false
+	}
 	return sm.State.IsConnected()
 }
 
 func (sm *stateMachine) IsSessionTime() bool {
+	if sm.State == nil {
+		return false
+	}
 	return sm.State.IsSessionTime()
 }
 


### PR DESCRIPTION
change in this PR:
- feat: add wait api.
- fix: guard sessionState.

詳細：
- InitiatorにWait関数を追加。
  - (想定よりは若干大掛かりになったが) Wait関数を追加。現状はSessionがAliveとなるまで（Logonのレスポンスが返るまで）Waitとしている。
    - 内部でSleepポーリングするだけだと外部監視するのとあまり変わらないので、作りこんでみた。
  - timeoutパラメータ指定版も定義。
  - Wait処理用のID発行のためのロジック追加。
  - state変化通知を受信するgoroutineを一つ追加。Wait側への配信もここから実施。
    - (処理タイミングにより) channel周りで少し不具合ありそうな気がするので再確認中。
- sessionのStateをガードする対応。
  - 元々のnilチェック漏れ。Sessionが作成されてすぐの辺りでアクセスしようとすると（Stateが未設定で）nil pointer accessとなったため。