### PR TITLE
feat: add other error to BusinessRejectReason

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -182,7 +182,7 @@ func NewOtherRejectError(err string) MessageRejectError {
 	return messageRejectError{text: err, rejectReason: rejectReasonOther}
 }
 
-//NewOtherBusinessRejectError returns a business MessageRejectError with the given error message
+//NewOtherBusinessRejectError returns a BusinessMessageRejectError with the given error message
 func NewOtherBusinessRejectError(err string) MessageRejectError {
 	return NewBusinessMessageRejectError(err, businessRejectReasonOther, nil)
 }

--- a/errors.go
+++ b/errors.go
@@ -26,6 +26,7 @@ const (
 	rejectReasonRepeatingGroupFieldsOutOfOrder            = 15
 	rejectReasonIncorrectNumInGroupCountForRepeatingGroup = 16
 	rejectReasonOther                                     = 99
+	rejectReasonBusinessOther                             = 0
 	// rejectReasonNonDataValueIncludesFieldDelimiter     = 17
 )
 
@@ -179,4 +180,9 @@ func sendingTimeAccuracyProblem() MessageRejectError {
 //NewOtherRejectError returns a MessageRejectError with the given error message
 func NewOtherRejectError(err string) MessageRejectError {
 	return messageRejectError{text: err, rejectReason: rejectReasonOther}
+}
+
+//NewBusinessOtherRejectError returns a business MessageRejectError with the given error message
+func NewBusinessOtherRejectError(err string) MessageRejectError {
+	return NewBusinessMessageRejectError(err, rejectReasonBusinessOther, nil)
 }

--- a/errors.go
+++ b/errors.go
@@ -26,7 +26,7 @@ const (
 	rejectReasonRepeatingGroupFieldsOutOfOrder            = 15
 	rejectReasonIncorrectNumInGroupCountForRepeatingGroup = 16
 	rejectReasonOther                                     = 99
-	rejectReasonBusinessOther                             = 0
+	businessRejectReasonOther                             = 0
 	// rejectReasonNonDataValueIncludesFieldDelimiter     = 17
 )
 
@@ -182,7 +182,7 @@ func NewOtherRejectError(err string) MessageRejectError {
 	return messageRejectError{text: err, rejectReason: rejectReasonOther}
 }
 
-//NewBusinessOtherRejectError returns a business MessageRejectError with the given error message
-func NewBusinessOtherRejectError(err string) MessageRejectError {
-	return NewBusinessMessageRejectError(err, rejectReasonBusinessOther, nil)
+//NewOtherBusinessRejectError returns a business MessageRejectError with the given error message
+func NewOtherBusinessRejectError(err string) MessageRejectError {
+	return NewBusinessMessageRejectError(err, businessRejectReasonOther, nil)
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -301,3 +301,24 @@ func TestNewOtherRejectError(t *testing.T) {
 		t.Error("Expected IsBusinessReject to be false\n")
 	}
 }
+
+func TestNewBusinessOtherRejectError(t *testing.T) {
+	var (
+		expectedErrorString  = "Custom error"
+		expectedRejectReason = 0
+	)
+	msgRej := NewBusinessOtherRejectError(expectedErrorString)
+
+	if strings.Compare(msgRej.Error(), expectedErrorString) != 0 {
+		t.Errorf("expected: %s, got: %s\n", expectedErrorString, msgRej.Error())
+	}
+	if msgRej.RejectReason() != expectedRejectReason {
+		t.Errorf("expected: %d, got: %d\n", expectedRejectReason, msgRej.RejectReason())
+	}
+	if msgRej.RefTagID() != nil {
+		t.Errorf("expected: nil, got: %d\n", *msgRej.RefTagID())
+	}
+	if !msgRej.IsBusinessReject() {
+		t.Error("Expected IsBusinessReject to be false\n")
+	}
+}

--- a/errors_test.go
+++ b/errors_test.go
@@ -302,12 +302,12 @@ func TestNewOtherRejectError(t *testing.T) {
 	}
 }
 
-func TestNewBusinessOtherRejectError(t *testing.T) {
+func TestNewOtherBusinessRejectError(t *testing.T) {
 	var (
 		expectedErrorString  = "Custom error"
 		expectedRejectReason = 0
 	)
-	msgRej := NewBusinessOtherRejectError(expectedErrorString)
+	msgRej := NewOtherBusinessRejectError(expectedErrorString)
 
 	if strings.Compare(msgRej.Error(), expectedErrorString) != 0 {
 		t.Errorf("expected: %s, got: %s\n", expectedErrorString, msgRej.Error())
@@ -319,6 +319,6 @@ func TestNewBusinessOtherRejectError(t *testing.T) {
 		t.Errorf("expected: nil, got: %d\n", *msgRej.RefTagID())
 	}
 	if !msgRej.IsBusinessReject() {
-		t.Error("Expected IsBusinessReject to be false\n")
+		t.Error("Expected IsBusinessReject to be true\n")
 	}
 }


### PR DESCRIPTION
##  概要
- business用のother errorも必要のため追加しました
- 使用例
```
	symbol, parseErr := shared_model.NewSymbol(symbolStr)
	if parseErr != nil {
		return nil, quickfix.NewBusinessOtherRejectError("Symbol value is invalid.")
	}
```
- 元々tagも追加しようと思いますが、textで十分表現できるのでそのままにしました