### PR TITLE
fix: lock timer.Stop

### DIFF
--- a/session.go
+++ b/session.go
@@ -740,11 +740,25 @@ func (s *session) onAdmin(msg interface{}) {
 func (s *session) run() {
 	s.Start(s)
 
-	s.stateTimer = internal.NewEventTimer(func() { s.sessionEvent <- internal.NeedHeartbeat })
-	s.peerTimer = internal.NewEventTimer(func() { s.sessionEvent <- internal.PeerTimeout })
+	// https://github.com/quickfixgo/quickfix/pull/452
+	done := make(chan struct{})
+
+	s.stateTimer = internal.NewEventTimer(func() {
+		select {
+		case <-done:
+		case s.sessionEvent <- internal.NeedHeartbeat:
+		}
+	})
+	s.peerTimer = internal.NewEventTimer(func() {
+		select {
+		case <-done:
+		case s.sessionEvent <- internal.PeerTimeout:
+		}
+	})
 	ticker := time.NewTicker(time.Second)
 
 	defer func() {
+		close(done)
 		s.stateTimer.Stop()
 		s.peerTimer.Stop()
 		ticker.Stop()


### PR DESCRIPTION
## implements
- fix: lock timer.Stop
  - quickfixgo/quickfix#452

## case
1. use dynamic session & set store session & ResetOnLogon=N
2. connect to acceptor
3. logout
4. remove initiator store file
5. connect to acceptor : targetTooLow error
    - after disconnect, cannot finish `session.run()` .
6. remove initiator store file
7. set initiator ResetOnLogon=Y
8. connect to acceptor : `Dynamic session %v failed to create`